### PR TITLE
ci: fix "unrelated histories" merge error

### DIFF
--- a/.github/workflows/release-via-comment.yml
+++ b/.github/workflows/release-via-comment.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          # ensure branches share histories
+          # see: https://github.com/actions/checkout/issues/125
+          fetch-depth: 0
 
       - name: Verify PR and dispatch release workflow
         uses: actions/github-script@v6


### PR DESCRIPTION
Set `actions/checkout` fetch depth to 0 (hoping) to ensure that branches have enough depth to share histories.