### PR TITLE
fix(typescript): use ES2022 target for node20

### DIFF
--- a/typescript/tsconfig.node20.json
+++ b/typescript/tsconfig.node20.json
@@ -8,6 +8,6 @@
 		"moduleResolution": "nodenext",
 		"resolveJsonModule": true,
 		"sourceMap": true,
-		"target": "ES2023"
+		"target": "ES2022"
 	}
 }


### PR DESCRIPTION
ES2023 does not seem to be supported, though TypeScript 5.0 should and the tsconfig schema includes it as an option.