### PR TITLE
ci: try to make release comments work again

### DIFF
--- a/.github/scripts/comment-on-new-pr.js
+++ b/.github/scripts/comment-on-new-pr.js
@@ -22,10 +22,10 @@ module.exports = async ({ context, github }) => {
 		repo: context.repo.repo,
 		issue_number: context.issue.number,
 		body: `
-Hey @${mention}, thanks for contributing! If you haven't read the contributing
+Hey @${mention}, thanks for contributing! If you haven't read the contributing \
 guide that outlines the process, you can do so [here](${contributingUrl}).
 
-Maintainers: once checks have passed, comment \`!release this\` and I'll begin
+Maintainers: once checks have passed, comment \`!release this\` and I'll begin \
 merging this for you.
 `.trim()
 	});


### PR DESCRIPTION
Despite using `git fetch --all`, git claims the head branch doesn't exist locally. Add an extra fetch specifically targeting the head branch to try to ensure the thing comes down.

I had previously prefixed all branch names with `origin/` but ran into some issue I don't remember, then changed to only prefixing branch names containing `/`. Let's try always prefixing with `origin/` again I guess.