### PR TITLE
ci: fetch after checkout so head is not current

### DIFF
--- a/.github/scripts/release-via-comment.js
+++ b/.github/scripts/release-via-comment.js
@@ -68,8 +68,8 @@ const fastForward = async (execGit, { pr }) => {
 	await execGit(["config", "--local", "user.name", USER_NAME]);
 	await execGit(["config", "--local", "user.email", USER_EMAIL]);
 	await execGit(["fetch", "--all"]);
-	await execGit(["fetch", ".", `${headOriginRef}:${pr.head.ref}`]);
 	await execGit(["checkout", pr.base.ref]);
+	await execGit(["fetch", ".", `${headOriginRef}:${pr.head.ref}`]);
 
 	if (isDownstream) {
 		console.log(


### PR DESCRIPTION
This should avoid the `refusing to fetch into branch 'refs/heads/...` error.