### PR TITLE
feat(eslint): use new `@typescript-eslint` configs

### DIFF
--- a/eslint/typescript.js
+++ b/eslint/typescript.js
@@ -10,9 +10,9 @@ module.exports = {
 		{
 			files: typescriptFiles,
 			extends: [
-				"plugin:@typescript-eslint/recommended",
-				"plugin:@typescript-eslint/recommended-requiring-type-checking",
-				"plugin:@typescript-eslint/strict",
+				"plugin:@typescript-eslint/recommended-type-checked",
+				"plugin:@typescript-eslint/strict-type-checked",
+				"plugin:@typescript-eslint/stylistic-type-checked",
 				"plugin:import/typescript",
 				"prettier",
 				require.resolve("./rules/typescript"),


### PR DESCRIPTION
BREAKING CHANGE: additional rules may be enabled by `@typescript-eslint` that cause new errors