### PR TITLE
feat(eslint): allow `ALL` as UPPER_CASE

### DIFF
--- a/eslint/rules/typescript/naming-convention.js
+++ b/eslint/rules/typescript/naming-convention.js
@@ -46,7 +46,7 @@ export const getTypescriptNamingConventionRule = ({
 		{
 			filter: {
 				match: true,
-				regex: "^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)$"
+				regex: "^(ALL|GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)$"
 			},
 			format: null,
 			selector: ["variableLike"]


### PR DESCRIPTION
This is used as a catch-all HTTP method in e.g., Next.js