### PR TITLE
ci: ignore dependabot commit styles

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,8 @@
 export default {
 	extends: ["@commitlint/config-conventional"],
+	// remove this if we can ever get dependabot to follow the rules
+	// https://github.com/dependabot/dependabot-core/issues/2445
+	ignores: [(message) => message.includes("Signed-off-by: dependabot[bot]")],
 	rules: {
 		"type-enum": [
 			2,


### PR DESCRIPTION
We don't have enough control over Dependabot's commits (yet).

See:
https://github.com/dependabot/dependabot-core/issues/2445