### PR TITLE
fix: remove `@types/eslint__js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
 		"@octokit/types": "^13.8.0",
 		"@semantic-release/git": "^10.0.1",
 		"@types/eslint-config-prettier": "^6.11.3",
-		"@types/eslint__js": "^9.14.0",
 		"@types/node": "22",
 		"@typescript-eslint/types": "^8.24.0",
 		"eslint": "^9.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       '@types/eslint-config-prettier':
         specifier: ^6.11.3
         version: 6.11.3
-      '@types/eslint__js':
-        specifier: ^9.14.0
-        version: 9.14.0
       '@types/node':
         specifier: '22'
         version: 22.13.9
@@ -682,10 +679,6 @@ packages:
 
   '@types/eslint-config-prettier@6.11.3':
     resolution: {integrity: sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==}
-
-  '@types/eslint__js@9.14.0':
-    resolution: {integrity: sha512-s0jepCjOJWB/GKcuba4jISaVpBudw3ClXJ3fUK4tugChUMQsp6kSwuA8Dcx6wFd/JsJqcY8n4rEpa5RTHs5ypA==}
-    deprecated: This is a stub types definition. @eslint/js provides its own type definitions, so you do not need this installed.
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -4542,10 +4535,6 @@ snapshots:
   '@types/doctrine@0.0.9': {}
 
   '@types/eslint-config-prettier@6.11.3': {}
-
-  '@types/eslint__js@9.14.0':
-    dependencies:
-      '@eslint/js': 9.21.0
 
   '@types/estree@1.0.6': {}
 


### PR DESCRIPTION
This package causes a TypeScript compilation error for some reason...

```
error TS2688: Cannot find type definition file for 'eslint__js'.
  The file is in the program because:
    Entry point for implicit type library 'eslint__js'
```

However, `@eslint/js` provides its own types now, so we don't need this anymore.