### PR TITLE
fix(stylelint): set up new `at-rule-no-deprecated`

### DIFF
--- a/stylelint/tailwind.js
+++ b/stylelint/tailwind.js
@@ -4,5 +4,13 @@
 import { defineConfig } from "stylelint-define-config";
 
 export default defineConfig({
-	extends: "stylelint-config-tailwindcss"
+	extends: "stylelint-config-tailwindcss",
+	rules: {
+		"at-rule-no-deprecated": [
+			true,
+			{
+				ignoreAtRules: ["apply"]
+			}
+		]
+	}
 });


### PR DESCRIPTION
This rule is newly introduced in stylelint v16.13.0. `@apply` is technically a valid CSS at-rule, but it's deprecated. However, Tailwind uses `@apply`, so we need to set up the rule to ignore it.