### PR TITLE
feat(eslint)!: replace no-array-push-push rule

### DIFF
--- a/eslint/configs/internal/unicorn.js
+++ b/eslint/configs/internal/unicorn.js
@@ -24,6 +24,14 @@ export const eslintUnicornConfig = config({
 		 */
 		"unicorn/consistent-destructuring": "error",
 		/**
+		 * Enforce consistent style for element existence checks with `indexOf()`,
+		 * `lastIndexOf()`, `findIndex()`, and `findLastIndex()`.
+		 *
+		 * 🔧 Fixable -
+		 * https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-existence-index-check.md
+		 */
+		"unicorn/consistent-existence-index-check": "error",
+		/**
 		 * Move function definitions to the highest possible scope.
 		 *
 		 * 🔧 Fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md
@@ -248,6 +256,22 @@ export const eslintUnicornConfig = config({
 		 */
 		"unicorn/no-unnecessary-await": "error",
 		/**
+		 * Disallow using `.length` or `Infinity` as the `end` argument of
+		 * `{Array,String,TypedArray}#slice()`.
+		 *
+		 * 🔧 Fixable -
+		 * https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-slice-end.md
+		 */
+		"unicorn/no-unnecessary-slice-end": "error",
+		/**
+		 * Disallow using `.length` or `Infinity` as the `deleteCount` or
+		 * `skipCount` argument of `Array#{splice,toSpliced}()`.
+		 *
+		 * 🔧 Fixable -
+		 * https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-array-splice-count.md
+		 */
+		"unicorn/no-unnecessary-array-splice-count": "error",
+		/**
 		 * Disallow unreadable array destructuring.
 		 *
 		 * 🔧 Fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unreadable-array-destructuring.md
@@ -445,6 +469,12 @@ export const eslintUnicornConfig = config({
 		 * 🚫 Not fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-logical-operator-over-ternary.md
 		 */
 		"unicorn/prefer-logical-operator-over-ternary": "error",
+		/**
+		 * Prefer `Math.min()` and `Math.max()` over ternaries for simple comparisons.
+		 *
+		 * 🔧 Fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-math-min-max.md
+		 */
+		"unicorn/prefer-math-min-max": "error",
 		/**
 		 * Enforce the use of `Math.trunc` instead of bitwise operators.
 		 *

--- a/eslint/configs/internal/unicorn.js
+++ b/eslint/configs/internal/unicorn.js
@@ -104,12 +104,6 @@ export const eslintUnicornConfig = config({
 		 */
 		"unicorn/no-array-method-this-argument": "error",
 		/**
-		 * Enforce combining multiple `Array#push()` into one call.
-		 *
-		 * 🔧 Fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-push-push.md
-		 */
-		"unicorn/no-array-push-push": "error",
-		/**
 		 * Disallow `Array#reduce()` and `Array#reduceRight()`.
 		 *
 		 * Disabled because `reduce` is useful for functional programming patterns.
@@ -549,6 +543,14 @@ export const eslintUnicornConfig = config({
 		 * 🔧 Fixable - https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-set-size.md
 		 */
 		"unicorn/prefer-set-size": "error",
+		/**
+		 * Enforce combining multiple `Array#push()`,
+		 * `Element#classList.{add,remove}()`, and `importScripts()` into one call.
+		 *
+		 * 🔧 Fixable -
+		 * https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-single-call.md
+		 */
+		"unicorn/prefer-single-call": "error",
 		/**
 		 * Prefer the spread operator over `Array.from(…)`, `Array#concat(…)`, `Array#{slice,toSpliced}()` and `String#split('')`.
 		 *

--- a/package.json
+++ b/package.json
@@ -164,5 +164,10 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"unrs-resolver"
+		]
 	}
 }


### PR DESCRIPTION
This rule has been replaced by `prefer-single-call`.

BREAKING CHANGE: `no-array-push-push` rule has been removed and replaced
with `prefer-single-call`, which enforces single calls to more methods
than just `Array#push`.

See:
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-single-call.md