### PR TITLE
feat(typescript)!: make next tsconfig stricter

### DIFF
--- a/typescript/tsconfig.next.json
+++ b/typescript/tsconfig.next.json
@@ -11,6 +11,8 @@
 		"module": "esnext",
 		"moduleResolution": "bundler",
 		"noEmit": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,


### PR DESCRIPTION
BREAKING CHANGE: the Next.js TypeScript configuration has been made stricter by disallowing fallthrough in switch statements and unchecked index access. If you need to relax these rules, set `noFallthroughCasesInSwitch` and `noUncheckedIndexedAccess` to `false` in your own tsconfig file.