### PR TITLE
feat(eslint)!: make next.js plugin a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 		"@babel/eslint-parser": "^7.26.8",
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
 		"@eslint-react/eslint-plugin": "^2.3.13",
-		"@next/eslint-plugin-next": "^15.1.7",
 		"@stylistic/eslint-plugin-jsx": "^4.2.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-import-resolver-alias": "^1.1.2",
@@ -125,6 +124,7 @@
 		"@commitlint/config-conventional": "^20.2.0",
 		"@eslint/eslintrc": "^3.2.0",
 		"@eslint/js": "^9.20.0",
+		"@next/eslint-plugin-next": "^15.1.7",
 		"@octokit/types": "^16.0.0",
 		"@semantic-release/git": "^10.0.1",
 		"@types/eslint-config-prettier": "^6.11.3",
@@ -141,12 +141,16 @@
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {
+		"@next/eslint-plugin-next": ">=15.0.0 <17",
 		"eslint": ">=9",
 		"prettier": ">=3.0.0 <4",
 		"stylelint": ">=16.3.1 <17",
 		"typescript": ">=5.0.0 <6"
 	},
 	"peerDependenciesMeta": {
+		"@next/eslint-plugin-next": {
+			"optional": true
+		},
 		"eslint": {
 			"optional": true
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@eslint-react/eslint-plugin':
         specifier: ^2.3.13
         version: 2.4.0(eslint@9.39.2(jiti@2.4.2))(typescript@5.9.3)
-      '@next/eslint-plugin-next':
-        specifier: ^15.1.7
-        version: 15.5.9
       '@stylistic/eslint-plugin-jsx':
         specifier: ^4.2.0
         version: 4.4.1(eslint@9.39.2(jiti@2.4.2))
@@ -117,6 +114,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.39.2
+      '@next/eslint-plugin-next':
+        specifier: ^15.1.7
+        version: 15.5.9
       '@octokit/types':
         specifier: ^16.0.0
         version: 16.0.0

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ export default getEslintConfig({
 	// treat *.js files as CommonJS instead of ES Modules
 	commonjs: true,
 
-	// for Next.js projects (implies `react`)
+	// for Next.js projects (implies `react`, requires `@next/eslint-plugin-next`)
 	nextjs: true,
 
 	// for Node.js projects
@@ -308,24 +308,24 @@ export default [
 
 Several Typescript configs are available to cover various scenarios:
 
-| Name                                 | Description                                                                                          |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `@haltcase/style/typescript/base`    | Baseline config, intended to be extended from.                                                       |
-| `@haltcase/style/typescript/bundler` | For use in bundled projects, most commonly [Vite](https://vitejs.dev/) + [React](https://react.dev). |
-| `@haltcase/style/typescript/next`    | For use in [Next.js](https://nextjs.org/) projects.                                                  |
-| `@haltcase/style/typescript/node`    | Default Node config, currently targeting Node 24.                                                    |
-| `@haltcase/style/typescript/node-ts` | Addon for other Node configs for use with Node's built-in TypeScript support.                        |
-| `@haltcase/style/typescript/node18`  | For projects targeting Node 18.                                                                      |
-| `@haltcase/style/typescript/node20`  | For projects targeting Node 20.                                                                      |
-| `@haltcase/style/typescript/node22`  | For projects targeting Node 22.                                                                      |
-| `@haltcase/style/typescript/node24`  | For projects targeting Node 24.                                                                      |
-| `@haltcase/style/typescript/web`     | For use in web projects.                                                                             |
+| Name                                 | Description                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `@haltcase/style/typescript/base`    | Baseline config, intended to be extended from.                                                           |
+| `@haltcase/style/typescript/bundler` | For use in bundled projects, most commonly [Vite](https://vitejs.dev/) + [React](https://react.dev).     |
+| `@haltcase/style/typescript/next`    | For use in [Next.js](https://nextjs.org/) projects. See the [Next.js](#nextjs) section for more details. |
+| `@haltcase/style/typescript/node`    | Default Node config, currently targeting Node 24.                                                        |
+| `@haltcase/style/typescript/node-ts` | Addon for other Node configs for use with Node's built-in TypeScript support.                            |
+| `@haltcase/style/typescript/node18`  | For projects targeting Node 18.                                                                          |
+| `@haltcase/style/typescript/node20`  | For projects targeting Node 20.                                                                          |
+| `@haltcase/style/typescript/node22`  | For projects targeting Node 22.                                                                          |
+| `@haltcase/style/typescript/node24`  | For projects targeting Node 24.                                                                          |
+| `@haltcase/style/typescript/web`     | For use in web projects.                                                                                 |
 
 Typically, you'll only need to extend from one of these:
 
 ```json
 {
-	"extends": "@haltcase/style/typescript/next"
+	"extends": "@haltcase/style/typescript/node"
 }
 ```
 
@@ -406,6 +406,47 @@ If you use Tailwind, you can additionally extend from `@haltcase/style/stylelint
 			"@haltcase/style/stylelint/tailwind"
 		]
 	}
+}
+```
+
+### Other workloads
+
+#### Next.js
+
+For Next.js projects, install `@next/eslint-plugin-next` as a development
+dependency.
+
+> [!TIP]
+> Keep your Next.js and `@next/eslint-plugin-next` versions in sync for best
+> compatibility.
+
+```sh
+# pnpm
+pnpm add -D @next/eslint-plugin-next
+
+# npm
+npm i -D @next/eslint-plugin-next
+```
+
+Then, enable the Next.js config in your ESLint configuration:
+
+```ts
+// eslint.config.js
+import { getEslintConfig } from "@haltcase/style/eslint";
+
+export default getEslintConfig({
+	nextjs: true
+});
+```
+
+See the [ESLint section](#eslint) for more details.
+
+If you're using TypeScript, you can extend from the Next.js-specific config:
+
+```jsonc
+// tsconfig.json
+{
+	"extends": "@haltcase/style/typescript/next"
 }
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: `@next/eslint-plugin-next` is no longer bundled and must be installed as a peer dependency.