### PR TITLE
feat(eslint)!: enable `you-might-not-need-an-effect`

### DIFF
--- a/eslint/configs/react.js
+++ b/eslint/configs/react.js
@@ -5,6 +5,7 @@ import * as eslintPluginImportX from "eslint-plugin-import-x";
 import eslintPluginJsxA11y from "eslint-plugin-jsx-a11y";
 import eslintPluginReactOriginal from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
+import eslintPluginYouMightNotNeedAnEffect from "eslint-plugin-react-you-might-not-need-an-effect";
 
 import { jsxFiles, typescriptJsxFiles } from "../constants.js";
 import { jsxA11yRules } from "../rules/jsx-a11y.js";
@@ -56,6 +57,11 @@ export const getEslintReactConfigInternal = (_options = {}) =>
 				{
 					name: "@haltcase/react/hooks",
 					...eslintPluginReactHooks.configs.flat.recommended
+				},
+
+				{
+					name: "@haltcase/react/you-might-not-need-an-effect",
+					...eslintPluginYouMightNotNeedAnEffect.configs.recommended
 				},
 
 				{

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"eslint-plugin-playwright": "^2.2.0",
 		"eslint-plugin-react": "^7.37.4",
 		"eslint-plugin-react-hooks": "^7.0.1",
+		"eslint-plugin-react-you-might-not-need-an-effect": "^0.8.3",
 		"eslint-plugin-regexp": "^2.7.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
 		"eslint-plugin-testing-library": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.2(jiti@2.4.2))
+      eslint-plugin-react-you-might-not-need-an-effect:
+        specifier: ^0.8.3
+        version: 0.8.3(eslint@9.39.2(jiti@2.4.2))
       eslint-plugin-regexp:
         specifier: ^2.7.0
         version: 2.10.0(eslint@9.39.2(jiti@2.4.2))
@@ -1721,6 +1724,12 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
+
+  eslint-plugin-react-you-might-not-need-an-effect@0.8.3:
+    resolution: {integrity: sha512-btIWlck7X39T3aRXuWpVRJc0SyfqeFjTzcctUnDf2VyEwwAsxPPxwviyvKv5gBxx3TaKkrHUO6fjqZoHvn7XPw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -6001,6 +6010,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react-you-might-not-need-an-effect@0.8.3(eslint@9.39.2(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.4.2)
+      globals: 16.5.0
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.4.2)):
     dependencies:


### PR DESCRIPTION
BREAKING CHANGE: more warnings will be reported with the addition of `eslint-plugin-you-might-not-need-an-effect`